### PR TITLE
Events Rang Error Handling

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -18,10 +18,17 @@ class EventsController < ApplicationController
   end
 
   def range
-    @events =
-      Event.where(date: date_type('from')..date_type('to')).sort_by do |event|
-        event['date']
-      end
+    if list_params
+      @events =
+        Event.where(date: date_type('from')..date_type('to')).sort_by do |event|
+          event['date']
+        end
+    else
+      render json: {
+        content_type: 'application/json',
+        status: 'error'
+      }, status: 422
+    end
   end
 
   def summary

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,7 +9,7 @@ class EventsController < ApplicationController
         status: 'error',
         errors: @event.errors.full_messages,
         content_type: 'application/json'
-      }, status: 422
+      }, status: 400
     end
   end
 
@@ -27,7 +27,7 @@ class EventsController < ApplicationController
       render json: {
         content_type: 'application/json',
         status: 'error'
-      }, status: 422
+      }, status: 400
     end
   end
 
@@ -40,7 +40,7 @@ class EventsController < ApplicationController
       render json: {
         content_type: 'application/json',
         status: 'error'
-      }, status: 422
+      }, status: 400
     end
   end
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1,6 +1,13 @@
 require 'rails_helper'
 
 describe 'GET /events?from=DATE&to=DATE' do
+  let(:events) {
+    dates = ["2015-05-26T09:00Z", "2015-09-26T09:00Z", "2015-05-14T09:00Z"]
+    events = []
+    dates.each do |date|
+      events << FactoryGirl.create(:event, date: date)
+    end
+  }
   let(:from_date) {'2015-05-13T00:00Z'}
   let(:to_date) {'2015-06-13T23:59Z'}
   let(:first_result) {response_json['events'][0]['date']}
@@ -10,13 +17,9 @@ describe 'GET /events?from=DATE&to=DATE' do
   let(:no_results_to_date) {'2015-04-13T23:59Z'}
 
   context 'given a valid start and stop date' do
-    it 'returns events within given date range' do
-      dates = ["2015-05-26T09:00Z", "2015-09-26T09:00Z", "2015-05-14T09:00Z"]
-      events = []
-      dates.each do |date|
-        events << FactoryGirl.create(:event, date: date)
-      end
+    before { expect(events.count).to eq(3) }
 
+    it 'returns events within given date range' do
       get "/events", {'from' => from_date,'to' => to_date}
 
       expect(response).to render_template("events/range")
@@ -28,8 +31,8 @@ describe 'GET /events?from=DATE&to=DATE' do
 
       #second event should not be included
       expect(response_json['events'].count).to eq(2)
-      expect(first_result).to_not eq(events[1].date.iso8601)
-      expect(second_result).to_not eq(events[1].date.iso8601)
+      expect(first_result).to_not eq(Event.all[1].date.iso8601)
+      expect(second_result).to_not eq(Event.all[1].date.iso8601)
 
       #results in ascending date order
       expect(second_result).to be > first_result

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 describe 'GET /events?from=DATE&to=DATE' do
   let(:events) {
-    dates = ["2015-05-26T09:00Z", "2015-09-26T09:00Z", "2015-05-14T09:00Z"]
+    dates = ["2015-05-26T09:00Z", "2015-09-26T09:00Z", "2015-05-14T09:00Z",
+             "2015-06-26T19:00Z", "2015-07-26T09:30Z", "2015-10-14T08:00Z"]
     events = []
     dates.each do |date|
       events << FactoryGirl.create(:event, date: date)
@@ -17,7 +18,7 @@ describe 'GET /events?from=DATE&to=DATE' do
   let(:no_results_to_date) {'2015-04-13T23:59Z'}
 
   context 'given a valid start and stop date' do
-    before { expect(events.count).to eq(3) }
+    before { expect(events.count).to eq(6) }
 
     it 'returns events within given date range' do
       get "/events", {'from' => from_date,'to' => to_date}
@@ -39,23 +40,17 @@ describe 'GET /events?from=DATE&to=DATE' do
     end
 
     it 'returns no results if none within given range' do
-      dates = ["2015-05-26T09:00Z", "2015-09-26T09:00Z", "2015-05-14T09:00Z",
-               "2015-06-26T19:00Z", "2015-07-26T09:30Z", "2015-10-14T08:00Z"]
-      events = []
-      dates.each do |date|
-        events << FactoryGirl.create(:event, date: date)
-      end
 
       get "/events", {'from' => no_results_from_date,'to' => no_results_to_date}
 
       expect(response).to render_template("events/range")
       expect(response.content_type).to eq('application/json')
       expect(response.status).to eq(200)
-      expect(response_json['events'].count).to eq(0)
+      expect(response_json.keys).to_not match(/events/)
     end
   end
 
-  context 'given a range with a start date that occurs after the end date' do
+  context 'given invalid "from" and "to" params' do
     #TODO: (TL) spec to show error if dates are reversed
   end
 end
@@ -114,7 +109,7 @@ describe 'GET /events/summary?from=DATE&to=DATE&by=TIMEFRAME' do
     end
   end
 
-  context 'given invalid from and to params' do
+  context 'given invalid "from" and "to" params' do
     it 'returns a {"status" : "error"} when start date > stop date' do
       get "/events/summary",
         {'from' => to_date,'to' => from_date, 'by' => 'day'}

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -55,7 +55,7 @@ describe 'GET /events?from=DATE&to=DATE' do
       get "/events", { 'from' => to_date,'to' => from_date }
 
       expect(response.content_type).to eq('application/json')
-      expect(response.status).to eq(422)
+      expect(response.status).to eq(400)
       expect(response_json['status']).to eq("error")
       expect(response_json.keys).to_not match(/events/)
     end
@@ -64,7 +64,7 @@ describe 'GET /events?from=DATE&to=DATE' do
       get "/events", {'from' => from_date}
 
       expect(response.content_type).to eq('application/json')
-      expect(response.status).to eq(422)
+      expect(response.status).to eq(400)
       expect(response_json['status']).to eq("error")
       expect(response_json.keys).to_not match(/events/)
     end
@@ -131,7 +131,7 @@ describe 'GET /events/summary?from=DATE&to=DATE&by=TIMEFRAME' do
         {'from' => to_date,'to' => from_date, 'by' => 'day'}
 
       expect(response.content_type).to eq('application/json')
-      expect(response.status).to eq(422)
+      expect(response.status).to eq(400)
       expect(response_json['status']).to eq("error")
       expect(response_json.keys).to_not match(/events/)
     end
@@ -141,7 +141,7 @@ describe 'GET /events/summary?from=DATE&to=DATE&by=TIMEFRAME' do
         {'from' => from_date, 'by' => 'day'}
 
       expect(response.content_type).to eq('application/json')
-      expect(response.status).to eq(422)
+      expect(response.status).to eq(400)
       expect(response_json['status']).to eq("error")
       expect(response_json.keys).to_not match(/events/)
     end
@@ -151,7 +151,7 @@ describe 'GET /events/summary?from=DATE&to=DATE&by=TIMEFRAME' do
         {'from' => from_date,'to' => to_date, 'by' => 'weeks'}
 
       expect(response.content_type).to eq('application/json')
-      expect(response.status).to eq(422)
+      expect(response.status).to eq(400)
       expect(response_json['status']).to eq("error")
       expect(response_json.keys).to_not match(/events/)
     end
@@ -178,7 +178,7 @@ describe 'POST /events' do
 
     event = Event.last
     expect(response.content_type).to eq('application/json')
-    expect(response.status).to eq(422)
+    expect(response.status).to eq(400)
     expect(response_json['status']).to eq("error")
   end
 end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -51,7 +51,23 @@ describe 'GET /events?from=DATE&to=DATE' do
   end
 
   context 'given invalid "from" and "to" params' do
-    #TODO: (TL) spec to show error if dates are reversed
+    it 'returns a {"status" : "error"} when start date > stop date' do
+      get "/events", { 'from' => to_date,'to' => from_date }
+
+      expect(response.content_type).to eq('application/json')
+      expect(response.status).to eq(422)
+      expect(response_json['status']).to eq("error")
+      expect(response_json.keys).to_not match(/events/)
+    end
+
+    it 'returns a {"status" : "error"} when "to" param is missing' do
+      get "/events", {'from' => from_date}
+
+      expect(response.content_type).to eq('application/json')
+      expect(response.status).to eq(422)
+      expect(response_json['status']).to eq("error")
+      expect(response_json.keys).to_not match(/events/)
+    end
   end
 end
 


### PR DESCRIPTION
If query doesn't have the required to- and from- params and params[:to] isn't greater than params[:from], then the user will be met with an error.  
